### PR TITLE
Update keymap.c for dichotomy/alairock

### DIFF
--- a/keyboards/dichotomy/keymaps/alairock/keymap.c
+++ b/keyboards/dichotomy/keymaps/alairock/keymap.c
@@ -58,9 +58,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 ),
 
 [_ADJUST] = LAYOUT( /* Shifted number/function layout, for per-key control.  Only active when shift is held, and number is toggled or held */
-  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,          _______, _______, KC_UP,   _______, _______, _______,
-  KC_F7,   KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,         _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______,
-  KC_F13,  KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,         _______, _______, _______, _______, _______, _______,
+  KC_F1,   KC_F2,   KC_F3,   KC_F4,   KC_F5,   KC_F6,          _______, KC_PGUP, KC_UP,   KC_PGDN, _______, _______,
+  KC_LGUI, KC_F8,   KC_F9,   KC_F10,  KC_F11,  KC_F12,         _______, KC_LEFT, KC_DOWN, KC_RGHT, _______, _______,
+  KC_LSFT, KC_F14,  KC_F15,  KC_F16,  KC_F17,  KC_F18,         _______, _______, _______, _______, _______, _______,
                              _______, _______, _______,        _______, _______, _______,
                     _______, _______, _______, _______,        _______, _______, _______, _______
 ),


### PR DESCRIPTION
## Description

Add page up and down next to arrows,
Add command and shift to layer, which helps with ergonomics while on this layer. F keys overwritten are not common and will soon be move to a new layer entirely. 

## Types of Changes

- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [x] Keymap/layout/userspace (addition or update)
- [ ] Documentation

## Issues Fixed or Closed by This PR

* Better layout for dichotomy/alairock

## Checklist

- [x] My code follows the code style of this project: [**C**](https://docs.qmk.fm/#/coding_conventions_c), [**Python**](https://docs.qmk.fm/#/coding_conventions_python)
- [x] I have read the [**PR Checklist** document](https://docs.qmk.fm/#/pr_checklist) and have made the appropriate changes.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
